### PR TITLE
Fix in DmgrOpen to comply with the ctype

### DIFF
--- a/pydigilent/djtg.py
+++ b/pydigilent/djtg.py
@@ -122,7 +122,7 @@ class Jtag(object):
 		self._hif = hif
 
 	@classmethod
-	def get_version(cls):
+	def get_version(self):
 		(ok, version) = lowlevel.DjtgGetVersion()
 		if not ok:
 			raise JtagError('General Jtag Error', 'Unable to fetch DJTG library version string')

--- a/pydigilent/lowlevel/dmgr.py
+++ b/pydigilent/lowlevel/dmgr.py
@@ -42,7 +42,7 @@ _DmgrOpen.restype = bool
 
 def DmgrOpen(szSel):
 	hif = HIF()
-	return (_DmgrOpen(ctypes.byref(hif), szSel), hif)
+	return (_DmgrOpen(ctypes.byref(hif), ctypes.c_char_p(szSel.encode('utf-8'))), hif)
 
 _DmgrOpenEx = _dmgr.DmgrOpenEx
 _DmgrOpenEx.argtypes = [ctypes.POINTER(HIF), ctypes.c_char_p, DTP, DTP]


### PR DESCRIPTION
Changed a line in DmgrOpen() to allow the wrapper to communicate correctly with the SDK while opening a device connection.
Changed a line in get_version() to better comply with current python norms.